### PR TITLE
Caching strategy for breed search

### DIFF
--- a/app/services/breed_services/search_service.rb
+++ b/app/services/breed_services/search_service.rb
@@ -11,7 +11,6 @@ module BreedServices
     def initialize(query_term: nil, include_images: 1, search_by: SEARCH_BY_OPTIONS.first)
       @query_term = query_term
       @include_images = include_images
-      @results = []
 
       raise ArgumentError unless SEARCH_BY_OPTIONS.include?(search_by)
 

--- a/spec/services/breed_services/search_service_spec.rb
+++ b/spec/services/breed_services/search_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Breed Search Service', type: :helper do
   
       it 'throws an error' do
         expect { @search.perform }.to raise_error
-        expect(@search.results).to be_empty
+        expect(@search.results.blank?).to be true
       end
     end
   


### PR DESCRIPTION
Caching breed search service. Only caching searches that matches one of the following:
- Searches are made by name (these are the ones that consume more runtime)
- Searches include more than 20 images

This may fixes #11 

Some drawback to doing this:
1. Caching the results of name searches can consume memory very quickly. I'm curious to see how much this can affect our redis memory capacity. This could probably lead to future issues